### PR TITLE
Add TIC component implementation and tests

### DIFF
--- a/examples/demo_tic.py
+++ b/examples/demo_tic.py
@@ -1,0 +1,25 @@
+"""Demonstration of the Temporal Information Condenser."""
+from torch import dot, tensor
+
+from src.tic import TIC
+
+
+def resonance(x, y):
+    return dot(x, y)
+
+
+def main():
+    histories = [
+        [tensor([1.0, 0.0]), tensor([0.0, 1.0])],
+        [tensor([1.0, 1.0]), tensor([2.0, 2.0])],
+    ]
+
+    tic = TIC()
+    attractor = tic.condense(histories, resonance)
+
+    print("Selected TIC attractor:", attractor)
+    print("Exported representation:", tic.to_dict())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tic/__init__.py
+++ b/src/tic/__init__.py
@@ -1,0 +1,4 @@
+"""TIC module initialization."""
+from .tic import TIC
+
+__all__ = ["TIC"]

--- a/src/tic/tic.py
+++ b/src/tic/tic.py
@@ -1,0 +1,88 @@
+"""Implementation of the Temporal Information Condenser (TIC)."""
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Sequence, Union
+
+from torch import Tensor, tensor
+
+VectorLike = Union[Tensor, Sequence[Union[int, float]], int, float]
+History = Sequence[VectorLike]
+Histories = Sequence[History]
+ResonanceFunction = Callable[[Tensor, Tensor], Union[Tensor, float, int]]
+
+
+def _ensure_tensor(value: VectorLike) -> Tensor:
+    """Convert a supported input type into a :class:`~torch.Tensor`."""
+    if isinstance(value, Tensor):
+        return value
+    return tensor(value)
+
+
+def _to_float(value: Union[Tensor, float, int]) -> float:
+    """Convert resonance scores to plain Python floats."""
+    if isinstance(value, Tensor):
+        flat = value.flatten()
+        return float(sum(flat._values))
+    return float(value)
+
+
+class TIC:
+    """Temporal Information Condenser.
+
+    The class selects an attractor from historical trajectories that
+    maximises the total resonance with all other points.
+    """
+
+    def __init__(self) -> None:
+        self.state: Optional[Tensor] = None
+
+    def condense(self, histories: Histories, resonance_func: ResonanceFunction) -> Optional[Tensor]:
+        """Condense historical trajectories into a single attractor.
+
+        Args:
+            histories: A sequence of histories where each history is a
+                sequence of vectors (or tensor-like objects).
+            resonance_func: A callable ``F(x, y)`` returning the resonance
+                between two points.
+
+        Returns:
+            The attractor tensor that maximises the total resonance, or
+            ``None`` if no histories are provided.
+        """
+
+        points: List[Tensor] = []
+        for history in histories:
+            for vector in history:
+                points.append(_ensure_tensor(vector))
+
+        if not points:
+            self.state = None
+            return None
+
+        best_point: Optional[Tensor] = None
+        best_score: Optional[float] = None
+
+        for candidate in points:
+            total_resonance = 0.0
+            for other in points:
+                total_resonance += _to_float(resonance_func(candidate, other))
+
+            if best_score is None or total_resonance > best_score:
+                best_score = total_resonance
+                best_point = candidate
+
+        self.state = best_point
+        return self.state
+
+    def get_state(self) -> Optional[Tensor]:
+        """Return the current TIC state."""
+
+        return self.state
+
+    def to_dict(self) -> dict:
+        """Export the TIC state as a dictionary."""
+
+        if self.state is None:
+            return {"tic": None}
+        values = self.state.flatten()._values[:]
+        return {"tic": values}

--- a/tests/test_tic.py
+++ b/tests/test_tic.py
@@ -1,0 +1,40 @@
+from torch import dot, tensor
+
+from src.tic import TIC
+
+
+def resonance(x, y):
+    return dot(x, y)
+
+
+def test_condense_selects_highest_resonance_attractor():
+    histories = [
+        [tensor([1.0, 0.0]), tensor([0.0, 1.0])],
+        [tensor([1.0, 1.0])],
+    ]
+
+    tic = TIC()
+    state = tic.condense(histories, resonance)
+
+    assert state is not None
+    assert state.flatten()._values == [1.0, 1.0]
+
+
+def test_get_state_returns_current_state():
+    histories = [[tensor([2.0, 0.0])], [tensor([0.0, 3.0])]]
+    tic = TIC()
+    tic.condense(histories, resonance)
+
+    state = tic.get_state()
+
+    assert state is not None
+    assert state.flatten()._values == tic.state.flatten()._values
+
+
+def test_to_dict_exports_state():
+    tic = TIC()
+    tic.state = tensor([4.0, 5.0])
+
+    result = tic.to_dict()
+
+    assert result == {"tic": [4.0, 5.0]}


### PR DESCRIPTION
## Summary
- implement the Temporal Information Condenser (TIC) with resonance-based attractor selection
- expose the TIC module along with a demo script for manual exploration
- add unit tests covering condensation, state retrieval, and dictionary export

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8f2d59e38833186a69320923f181b