### PR TITLE
Add resonance loss and ML integration demo

### DIFF
--- a/examples/demo_ml.py
+++ b/examples/demo_ml.py
@@ -1,0 +1,73 @@
+"""Demonstration of the ResonanceLoss in a toy classification loop."""
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+import torch
+
+from src.spiral.loss import ResonanceLoss
+
+
+class LinearClassifier(torch.nn.Module):
+    """Very small linear model backed by the lightweight torch shim."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.weights = torch.tensor([0.0, 0.0])
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        values = features.flatten()._values
+        weights = self.weights.flatten()._values
+        score = sum(w * x for w, x in zip(weights, values))
+        return torch.tensor(score)
+
+    def update(self, features: torch.Tensor, gradient: float, lr: float) -> None:
+        values = features.flatten()._values
+        weights = self.weights.flatten()._values
+        self.weights = torch.tensor([w - lr * gradient * x for w, x in zip(weights, values)])
+
+
+def mse_loss(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    diff = prediction.item() - target.item()
+    return torch.tensor(diff * diff)
+
+
+def generate_dummy_data() -> Iterable[Tuple[torch.Tensor, torch.Tensor]]:
+    samples = [
+        (torch.tensor([1.0, 0.0]), torch.tensor(0.0)),
+        (torch.tensor([0.0, 1.0]), torch.tensor(1.0)),
+        (torch.tensor([0.8, 0.2]), torch.tensor(0.0)),
+        (torch.tensor([0.2, 0.9]), torch.tensor(1.0)),
+    ]
+    return samples
+
+
+def main() -> None:
+    model = LinearClassifier()
+    tic_attractor = torch.tensor([0.0, 1.0])
+    loss_fn = ResonanceLoss(mse_loss, lambda_weight=0.2)
+    data = list(generate_dummy_data())
+
+    for epoch in range(5):
+        total_loss = 0.0
+        for features, label in data:
+            prediction = model(features)
+            loss = loss_fn(prediction, label, tic_attractor)
+            total_loss += loss.item()
+
+            # Basic gradient descent step for the MSE component.
+            gradient = 2.0 * (prediction.item() - label.item())
+            # Encourage the model to align with the TIC by nudging the gradient.
+            resonance = loss_fn.resonance(prediction, tic_attractor)
+            gradient -= loss_fn.lambda_weight * (1.0 - resonance)
+            model.update(features, gradient, lr=0.1)
+
+        avg_loss = total_loss / len(data)
+        print(f"Epoch {epoch + 1}: avg_loss={avg_loss:.4f}, weights={model.weights.flatten()._values}")
+
+    final_alignment = loss_fn.resonance(model(torch.tensor([0.0, 1.0])), tic_attractor)
+    print(f"Final resonance with TIC: {final_alignment:.3f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spiral/__init__.py
+++ b/src/spiral/__init__.py
@@ -1,0 +1,5 @@
+"""Spiral ML utilities for the Rings of Saturn project."""
+
+from .loss import ResonanceLoss
+
+__all__ = ["ResonanceLoss"]

--- a/src/spiral/loss.py
+++ b/src/spiral/loss.py
@@ -1,0 +1,67 @@
+"""Loss functions for Spiral ML integrations."""
+from __future__ import annotations
+
+from typing import Callable, Union
+
+import torch
+
+Scalar = Union[float, int]
+LossValue = Union[Scalar, torch.Tensor]
+
+
+def _to_float(value: LossValue) -> float:
+    """Convert supported loss outputs to a floating point number."""
+    if isinstance(value, torch.Tensor):
+        return value.item()
+    return float(value)
+
+
+class ResonanceLoss(torch.nn.Module):
+    """Combine task loss with a resonance-based regularizer.
+
+    Parameters
+    ----------
+    task_loss:
+        Callable returning the base loss for the task. It must accept the
+        prediction tensor and target tensor and return either a Python scalar
+        or a :class:`torch.Tensor` containing a single value.
+    lambda_weight:
+        Weight applied to the resonance penalty term. Must be non-negative.
+    """
+
+    def __init__(self, task_loss: Callable[[torch.Tensor, torch.Tensor], LossValue], lambda_weight: float = 1.0) -> None:
+        super().__init__()
+        if lambda_weight < 0:
+            raise ValueError("lambda_weight must be non-negative")
+        self.task_loss = task_loss
+        self.lambda_weight = float(lambda_weight)
+
+    def forward(self, prediction: torch.Tensor, target: torch.Tensor, tic: torch.Tensor) -> torch.Tensor:
+        """Compute the total loss value.
+
+        The total loss is defined as ``L_task + lambda_weight * (1 - F)``, where
+        ``F`` is the cosine similarity between the prediction and the TIC
+        attractor.
+        """
+
+        base_loss = self.task_loss(prediction, target)
+        base_value = _to_float(base_loss)
+        resonance = self.resonance(prediction, tic)
+        total = base_value + self.lambda_weight * (1.0 - resonance)
+        return torch.tensor(total)
+
+    def resonance(self, prediction: torch.Tensor, tic: torch.Tensor) -> float:
+        """Return the cosine similarity between prediction and TIC."""
+
+        pred_flat = prediction.flatten()
+        tic_flat = tic.flatten()
+        pred_norm = pred_flat.norm().item()
+        tic_norm = tic_flat.norm().item()
+        if pred_norm == 0.0 or tic_norm == 0.0:
+            return 0.0
+        similarity = torch.dot(pred_flat, tic_flat).item() / (pred_norm * tic_norm)
+        # Clamp for numerical stability in edge cases where rounding causes overflow
+        return max(-1.0, min(1.0, similarity))
+
+
+__all__ = ["ResonanceLoss"]

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -1,0 +1,43 @@
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import torch
+
+from src.spiral.loss import ResonanceLoss
+
+
+def mse_loss(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    pred_vals = prediction.flatten()._values
+    target_vals = target.flatten()._values
+    if len(pred_vals) != len(target_vals):
+        raise ValueError("prediction and target must have the same size")
+    error = [(p - t) for p, t in zip(pred_vals, target_vals)]
+    return torch.tensor(sum(e * e for e in error))
+
+
+class IdentityModel(torch.nn.Module):
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return features
+
+
+def test_resonance_loss_rewards_resonant_predictions():
+    model = IdentityModel()
+    tic = torch.tensor([0.0, 1.0])
+    target = torch.tensor([0.0, 0.0])
+    loss_fn = ResonanceLoss(mse_loss, lambda_weight=0.5)
+
+    non_resonant_input = torch.tensor([1.0, 0.0])
+    resonant_input = torch.tensor([0.0, 1.0])
+
+    non_resonant_prediction = model(non_resonant_input)
+    resonant_prediction = model(resonant_input)
+
+    non_resonant_loss = loss_fn(non_resonant_prediction, target, tic).item()
+    resonant_loss = loss_fn(resonant_prediction, target, tic).item()
+
+    assert math.isclose(resonant_loss, 1.0, rel_tol=1e-6)
+    assert math.isclose(non_resonant_loss, 1.5, rel_tol=1e-6)
+    assert resonant_loss < non_resonant_loss

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -53,4 +53,21 @@ def equal(x: Tensor, y: Tensor) -> bool:
     return x.flatten()._values == y.flatten()._values
 
 
-__all__ = ["Tensor", "tensor", "dot", "equal"]
+class Module:
+    """Minimal drop-in replacement for :class:`torch.nn.Module`."""
+
+    def forward(self, *args, **kwargs):  # pragma: no cover - override required
+        raise NotImplementedError
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+class _NNNamespace:
+    Module = Module
+
+
+nn = _NNNamespace()
+
+
+__all__ = ["Tensor", "tensor", "dot", "equal", "nn", "Module"]


### PR DESCRIPTION
## Summary
- add a lightweight `torch.nn.Module` implementation to the torch shim
- implement the `ResonanceLoss` regularizer and export it from the new `spiral` package
- provide tests and a demo script showing ML integration with the resonance loss

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8f538a3c48331a6b8dc910056a823