### PR TITLE
Add mock zero-knowledge ML utilities and demo

### DIFF
--- a/examples/demo_zkml.py
+++ b/examples/demo_zkml.py
@@ -1,0 +1,25 @@
+"""Demonstration script for the mock zero-knowledge ML pipeline."""
+
+from src.zkml import ZKML
+
+
+def main() -> None:
+    zkml = ZKML()
+
+    # Define a dummy linear model for demonstration purposes.
+    def model(x):
+        return 3 * x + 1
+
+    x = 4
+    y, proof = zkml.zk_inference(model, x)
+
+    print(f"Input: {x}")
+    print(f"Model output: {y}")
+    print(f"Proof: {proof}")
+
+    is_valid = zkml.verify_inference(proof, x, y)
+    print(f"Proof valid: {is_valid}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/zkml/__init__.py
+++ b/src/zkml/__init__.py
@@ -1,0 +1,5 @@
+"""Zero-Knowledge Machine Learning utilities."""
+
+from .zkml import ZKML
+
+__all__ = ["ZKML"]

--- a/src/zkml/zkml.py
+++ b/src/zkml/zkml.py
@@ -1,0 +1,68 @@
+"""Mock implementation of zero-knowledge machine learning primitives."""
+from __future__ import annotations
+
+from typing import Any, Callable, Tuple
+
+
+class ZKML:
+    """Utility class to perform zero-knowledge machine learning operations.
+
+    The implementation provided here is a lightweight mock that simulates
+    zero-knowledge inference by returning a placeholder proof string. This
+    makes it easy to plug in a real zk-SNARK or zk-STARK backend later on
+    without having to touch the higher level application code.
+    """
+
+    #: Placeholder proof string used by the mock implementation.
+    PROOF_PLACEHOLDER = "ZK-PROOF"
+
+    def zk_inference(self, model: Callable[[Any], Any], x: Any) -> Tuple[Any, str]:
+        """Run the provided model on ``x`` and return the output and proof.
+
+        Parameters
+        ----------
+        model:
+            A callable that represents the machine learning model. The callable
+            must accept ``x`` and return an inference result.
+        x:
+            The input data for the model.
+
+        Returns
+        -------
+        Tuple[Any, str]
+            A tuple containing the model output ``y`` and a placeholder proof
+            string.
+        """
+
+        y = model(x)
+        proof = self.PROOF_PLACEHOLDER
+        return y, proof
+
+    def verify_inference(self, proof: str, x: Any, y: Any) -> bool:
+        """Verify the proof for the inference result.
+
+        The mock implementation simply checks whether the provided proof
+        matches the placeholder string. ``x`` and ``y`` are accepted to mirror
+        the interface of a potential real implementation, but they are not
+        used in the verification step.
+
+        Parameters
+        ----------
+        proof:
+            The proof string to verify.
+        x:
+            The input data used for the inference. Currently unused.
+        y:
+            The inference result. Currently unused.
+
+        Returns
+        -------
+        bool
+            ``True`` if the provided proof matches the placeholder string,
+            ``False`` otherwise.
+        """
+
+        return proof == self.PROOF_PLACEHOLDER
+
+
+__all__ = ["ZKML"]

--- a/tests/test_zkml.py
+++ b/tests/test_zkml.py
@@ -1,0 +1,26 @@
+"""Tests for the mock zero-knowledge machine learning utilities."""
+
+from src.zkml import ZKML
+
+
+def test_zk_inference_returns_output_and_proof():
+    zkml = ZKML()
+
+    def model(x):
+        return x * 2
+
+    x = 5
+    y, proof = zkml.zk_inference(model, x)
+
+    assert y == 10
+    assert proof == zkml.PROOF_PLACEHOLDER
+
+
+def test_verify_inference_accepts_valid_proof():
+    zkml = ZKML()
+
+    x = 3
+    y = 6
+    proof = zkml.PROOF_PLACEHOLDER
+
+    assert zkml.verify_inference(proof, x, y)


### PR DESCRIPTION
## Summary
- add a mock ZKML helper that returns a placeholder proof for model inference
- provide unit tests and an example script demonstrating the workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8f55b564083318a3f054421c0ab89