### PR TITLE
Implement Block 1 ledger, HDAG, and spiral modules

### DIFF
--- a/src/hdag/hdag.py
+++ b/src/hdag/hdag.py
@@ -1,47 +1,120 @@
-"""HDAG module for Spiral-HDAG-TIC-ZKML project."""
+"""HDAG module storing tensor nodes with persistent JSON backing."""
 from __future__ import annotations
 
+import json
+import math
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Tuple
 
 import torch
+
+NodeName = str
+Edge = Tuple[NodeName, NodeName, float]
 
 
 @dataclass
 class HDAG:
-    """Hierarchical Directed Acyclic Graph composed of tensor nodes."""
+    """Hierarchical Directed Acyclic Graph composed of tensor nodes.
 
-    nodes: Dict[str, torch.Tensor] = field(default_factory=dict)
-    edges: List[Tuple[str, str, float]] = field(default_factory=list)
+    Nodes and edges are persisted to a JSON file (``storage_path``). The graph can
+    be reloaded by instantiating :class:`HDAG` with the same storage path.
+    """
 
-    def add_node(self, node_id: str, tensor: torch.Tensor) -> None:
-        """Add a tensor node to the graph."""
-        if not isinstance(tensor, torch.Tensor):
-            raise TypeError("tensor must be a torch.Tensor")
-        self.nodes[node_id] = tensor
+    storage_path: Path | str | None = None
+    similarity_fn: Callable[[torch.Tensor, torch.Tensor], float] | None = None
+    nodes: Dict[NodeName, torch.Tensor] = field(init=False, default_factory=dict)
+    edges: List[Edge] = field(init=False, default_factory=list)
 
-    def add_edge(self, src: str, dst: str, weight: float) -> None:
-        """Add a directed edge between two nodes with the given weight."""
-        if src not in self.nodes:
-            raise KeyError(f"Source node '{src}' does not exist")
-        if dst not in self.nodes:
-            raise KeyError(f"Destination node '{dst}' does not exist")
-        self.edges.append((src, dst, float(weight)))
+    def __post_init__(self) -> None:
+        if isinstance(self.storage_path, str):
+            self.storage_path = Path(self.storage_path)
+        if self.similarity_fn is None:
+            self.similarity_fn = self._cosine_similarity
+        self._load()
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    def _load(self) -> None:
+        if not isinstance(self.storage_path, Path) or not self.storage_path.exists():
+            self.nodes = {}
+            self.edges = []
+            return
+
+        data = json.loads(self.storage_path.read_text())
+        nodes_serialised = data.get("nodes", {})
+        self.nodes = {name: torch.tensor(values) for name, values in nodes_serialised.items()}
+        self.edges = [tuple(edge) for edge in data.get("edges", [])]  # type: ignore[list-item]
+
+    def _save(self) -> None:
+        if not isinstance(self.storage_path, Path):
+            return
+        serialised = {
+            "nodes": {name: self._tensor_to_list(tensor) for name, tensor in self.nodes.items()},
+            "edges": list(self.edges),
+        }
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        self.storage_path.write_text(json.dumps(serialised, sort_keys=True))
+
+    # ------------------------------------------------------------------
+    def add_node(self, name: NodeName, vector: torch.Tensor) -> None:
+        """Add or update a node in the DAG."""
+
+        self.nodes[name] = self._as_tensor(vector)
+        self._save()
+
+    def add_edge(self, u: NodeName, v: NodeName, weight: float) -> None:
+        """Add a directed, weighted edge between nodes ``u`` and ``v``."""
+
+        if u not in self.nodes or v not in self.nodes:
+            raise KeyError("Both nodes must exist before adding an edge.")
+        self.edges.append((u, v, float(weight)))
+        self._save()
+
+    def neighbors(self, node: NodeName) -> List[Tuple[NodeName, float]]:
+        """Return outgoing neighbours from ``node``."""
+
+        if node not in self.nodes:
+            raise KeyError(f"Node '{node}' does not exist")
+        return [(dst, w) for src, dst, w in self.edges if src == node]
 
     def resonance(self, x: torch.Tensor, y: torch.Tensor) -> float:
-        """Calculate the cosine similarity between two tensors."""
-        if not isinstance(x, torch.Tensor) or not isinstance(y, torch.Tensor):
-            raise TypeError("Both inputs must be torch.Tensor instances")
-        x_norm = x.norm()
-        y_norm = y.norm()
-        if x_norm.item() == 0 or y_norm.item() == 0:
-            raise ValueError("Cannot compute cosine similarity for zero vector")
-        numerator = torch.dot(x.flatten(), y.flatten()).item()
-        denominator = x_norm.item() * y_norm.item()
-        return numerator / denominator
+        """Compute the resonance score (cosine similarity by default)."""
 
-    def neighbors(self, node_id: str) -> List[Tuple[str, float]]:
-        """Return neighbors of a given node as (neighbor_id, weight)."""
-        if node_id not in self.nodes:
-            raise KeyError(f"Node '{node_id}' does not exist")
-        return [(dst, weight) for src, dst, weight in self.edges if src == node_id]
+        return self.similarity_fn(x, y)  # type: ignore[return-value]
+
+    @staticmethod
+    def _cosine_similarity(x: torch.Tensor, y: torch.Tensor) -> float:
+        x_vals = HDAG._tensor_to_list(x)
+        y_vals = HDAG._tensor_to_list(y)
+        if len(x_vals) != len(y_vals):
+            raise ValueError("Vectors must share dimensionality")
+        x_norm = math.sqrt(sum(value * value for value in x_vals))
+        y_norm = math.sqrt(sum(value * value for value in y_vals))
+        if x_norm == 0.0 or y_norm == 0.0:
+            raise ValueError("Cannot compute cosine similarity for zero vectors")
+        dot_product = sum(a * b for a, b in zip(x_vals, y_vals))
+        return dot_product / (x_norm * y_norm)
+
+    def __len__(self) -> int:
+        return len(self.nodes)
+
+    def __contains__(self, item: object) -> bool:
+        return isinstance(item, str) and item in self.nodes
+
+    def items(self) -> Iterable[Tuple[NodeName, torch.Tensor]]:
+        return self.nodes.items()
+
+    @staticmethod
+    def _tensor_to_list(tensor: torch.Tensor) -> List[float]:
+        if hasattr(tensor, "tolist"):
+            return list(tensor.tolist())
+        if hasattr(tensor, "__iter__"):
+            return [float(v) for v in tensor]
+        return [float(tensor)]
+
+    @staticmethod
+    def _as_tensor(vector: torch.Tensor) -> torch.Tensor:
+        if isinstance(vector, torch.Tensor):
+            return torch.tensor(vector)
+        raise TypeError("vector must be a torch.Tensor")

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,4 +1,5 @@
-"""Tests for the Ledger component."""
+"""Tests for the Ledger module."""
+from __future__ import annotations
 
 import os
 import sys
@@ -7,42 +8,48 @@ ROOT = os.path.dirname(os.path.dirname(__file__))
 SRC_PATH = os.path.join(ROOT, "src")
 if SRC_PATH not in sys.path:
     sys.path.insert(0, SRC_PATH)
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
 
-from ledger.ledger import Ledger
+import pytest
+import torch
+
+from ledger.ledger import Ledger  # noqa: E402
+from spiral import Spiral  # noqa: E402
 
 
-def test_add_transaction():
-    ledger = Ledger()
+def test_create_block_embeds_spiral_projection():
+    spiral = Spiral(a=2.0, b=1.0, c=0.5)
+    ledger = Ledger(spiral=spiral)
     ledger.add_transaction({"from": "Alice", "to": "Bob", "amount": 10})
-    assert ledger.pending_transactions == [
-        {"from": "Alice", "to": "Bob", "amount": 10}
-    ]
-
-
-def test_create_block():
-    ledger = Ledger()
-    ledger.add_transaction("tx1")
-    ledger.add_transaction("tx2")
     block = ledger.create_block()
 
-    assert len(ledger.chain) == 1
-    assert ledger.pending_transactions == []
     assert block["index"] == 0
-    assert block["transactions"] == ["tx1", "tx2"]
-    assert block["prev_hash"] == "0"
-    assert block["hash"] == ledger.hash_block(block)
+    assert block["projection"][-1] == pytest.approx(0.0)
+    assert len(block["projection"]) == 5
+    assert ledger.validate_chain() is True
 
 
-def test_validate_chain():
+def test_chain_validation_detects_tampering():
     ledger = Ledger()
-    ledger.add_transaction("tx1")
+    ledger.add_transaction({"tx": 1})
     ledger.create_block()
-    ledger.add_transaction("tx2")
+    ledger.add_transaction({"tx": 2})
     ledger.create_block()
 
     assert ledger.validate_chain() is True
-
-    # Tamper with a block
-    ledger.chain[1]["transactions"].append("invalid")
-
+    ledger.chain[1]["transactions"].append({"tx": "tampered"})
     assert ledger.validate_chain() is False
+
+
+def test_projection_matches_spiral():
+    spiral = Spiral()
+    ledger = Ledger(spiral=spiral)
+    ledger.create_block()
+    ledger.add_transaction({"value": 1})
+    block = ledger.create_block()
+
+    expected = spiral.map(1.0)
+    projection_values = list(block["projection"])
+    for actual, expected_value in zip(projection_values, expected.tolist()):
+        assert actual == pytest.approx(expected_value)

--- a/tests/test_spiral.py
+++ b/tests/test_spiral.py
@@ -1,6 +1,19 @@
-import math
+"""Tests for the Spiral module."""
+from __future__ import annotations
 
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+SRC_PATH = os.path.join(ROOT, "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
+
+import math
 import pytest
+import torch
 
 from spiral import Spiral
 
@@ -13,24 +26,33 @@ def _matplotlib():
     return pyplot
 
 
-def test_spiral_point_has_positive_length():
+def test_map_returns_expected_tensor():
+    spiral = Spiral(a=1.0, b=0.5, c=0.2)
+    theta = math.pi / 4
+    point = spiral.map(theta)
+
+    expected = torch.tensor(
+        [
+            spiral.a * math.cos(theta),
+            spiral.a * math.sin(theta),
+            spiral.b * math.cos(2 * theta),
+            spiral.b * math.sin(2 * theta),
+            spiral.c * theta,
+        ]
+    )
+    assert isinstance(point, torch.Tensor)
+    for actual, expected_value in zip(point.tolist(), expected.tolist()):
+        assert actual == pytest.approx(expected_value)
+
+
+def test_resonance_static_method():
+    vector = (1.0, 2.0, 3.0)
+    assert pytest.approx(1.0) == Spiral.resonance(vector, vector)
+    assert pytest.approx(0.0, abs=1e-6) == Spiral.resonance((1, 0, 0), (0, 1, 0))
+
+
+def test_plot_projects_to_three_dimensions(_matplotlib):
     spiral = Spiral()
-    point = spiral.spiral(math.pi / 4)
-    length = math.sqrt(sum(coord ** 2 for coord in point))
-    assert length > 0
-
-
-def test_resonance_behaviour():
-    spiral = Spiral()
-    point = spiral.spiral(math.pi / 3)
-    assert pytest.approx(1.0) == spiral.resonance(point, point)
-
-    orthogonal_x = (1, 0, 0, 0, 0)
-    orthogonal_y = (0, 1, 0, 0, 0)
-    assert abs(spiral.resonance(orthogonal_x, orthogonal_y)) < 1e-6
-
-
-def test_plot_3d_runs_without_errors(_matplotlib):
-    spiral = Spiral()
-    fig, _ = spiral.plot_3d(n_points=50)
+    fig, ax = spiral.plot(n_points=10)
+    assert ax.name == "3d"
     _matplotlib.close(fig)

--- a/torch/__init__.py
+++ b/torch/__init__.py
@@ -33,6 +33,27 @@ class Tensor:
             raise ValueError("Can only convert a single element tensor to a Python scalar")
         return self._values[0]
 
+    def tolist(self) -> list[float]:
+        return self._values[:]
+
+    def detach(self) -> "Tensor":
+        return Tensor(self)
+
+    def cpu(self) -> "Tensor":
+        return Tensor(self)
+
+    def clone(self) -> "Tensor":
+        return Tensor(self)
+
+    def __iter__(self):  # pragma: no cover - trivial iterator
+        return iter(self._values)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._values)
+
+    def __getitem__(self, item):  # pragma: no cover - trivial
+        return self._values[item]
+
     def __repr__(self) -> str:  # pragma: no cover - debug helper
         return f"Tensor({self._values!r})"
 


### PR DESCRIPTION
## Summary
- implement ledger blocks with spiral projections and validation helpers
- add HDAG graph with JSON persistence and configurable cosine resonance
- provide spiral mapping and plotting utilities plus supporting tests and torch shim updates

## Testing
- pytest tests/test_spiral.py tests/test_ledger.py tests/test_hdag.py

------
https://chatgpt.com/codex/tasks/task_e_68d9cc5775208331acc9e817d18fae6e