### PR TITLE
Add dashboard backend routes and React frontend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
         git \
+        nodejs \
+        npm \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -15,6 +17,14 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+
+WORKDIR /app/src/dashboard/frontend
+RUN npm install \
+    && npm run build \
+    && npm cache clean --force \
+    && rm -rf node_modules
+
+WORKDIR /app
 
 EXPOSE 8000
 

--- a/fastapi/staticfiles.py
+++ b/fastapi/staticfiles.py
@@ -1,0 +1,6 @@
+"""Stub StaticFiles module so tests can import the attribute."""
+from __future__ import annotations
+
+from . import StaticFiles
+
+__all__ = ["StaticFiles"]

--- a/src/dashboard/backend/__init__.py
+++ b/src/dashboard/backend/__init__.py
@@ -1,0 +1,5 @@
+"""Backend utilities for the Rings of Saturn dashboard."""
+
+from .routes import router
+
+__all__ = ["router"]

--- a/src/dashboard/backend/routes.py
+++ b/src/dashboard/backend/routes.py
@@ -1,0 +1,129 @@
+"""FastAPI router powering the Rings of Saturn dashboard endpoints."""
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+from fastapi import APIRouter, Query
+
+from spiral.spiral import Spiral
+
+from .services import hdag_service, ledger_service, tic_service
+from .state import get_last_proof
+
+router = APIRouter(tags=["dashboard"])
+
+
+def _serialise_ledger() -> Dict[str, List[Dict[str, object]]]:
+    """Return a serialisable snapshot of the ledger state."""
+
+    chain = []
+    for block in ledger_service.to_dict().get("chain", []):
+        block_copy = dict(block)
+        projection = block_copy.get("projection")
+        if hasattr(projection, "tolist"):
+            block_copy["projection"] = list(projection.tolist())
+        chain.append(block_copy)
+    pending = [dict(tx) for tx in getattr(ledger_service, "pending_transactions", [])]
+    return {"chain": chain, "pending": pending}
+
+
+def _serialise_hdag() -> Dict[str, object]:
+    """Return nodes and edges from the HDAG service."""
+
+    nodes = [
+        {"id": name, "vector": hdag_service._tensor_to_list(vector)}
+        for name, vector in hdag_service.items()
+    ]
+    edges = [
+        {"source": src, "target": dst, "weight": float(weight)}
+        for src, dst, weight in getattr(hdag_service, "edges", [])
+    ]
+    return {"nodes": nodes, "edges": edges}
+
+
+def _tic_history() -> List[List[float]]:
+    """Generate a small deterministic TIC history for visualisation."""
+
+    base = [
+        [math.cos(idx), math.sin(idx), math.cos(idx) * math.sin(idx)]
+        for idx in [0.0, 0.7, 1.4, 2.1, 2.8, 3.5]
+    ]
+    if tic_service.state is not None:
+        base.append(tic_service._to_flat_list(tic_service.state))
+    return base
+
+
+@router.get("/ledger")
+def get_ledger() -> Dict[str, object]:
+    """Return the current ledger chain and pending transactions."""
+
+    return _serialise_ledger()
+
+
+@router.get("/hdag")
+def get_hdag() -> Dict[str, object]:
+    """Return nodes and edges used to build the HDAG visualisation."""
+
+    return _serialise_hdag()
+
+
+@router.get("/spiral")
+def get_spiral(
+    n: int = Query(100, ge=1, le=2000, description="Number of spiral points"),
+    a: float = Query(1.0, description="First radial coefficient"),
+    b: float = Query(0.5, description="Second radial coefficient"),
+    c: float = Query(0.1, description="Axial growth coefficient"),
+) -> Dict[str, object]:
+    """Return ``n`` points sampled from the configured spiral."""
+
+    spiral = Spiral(a=a, b=b, c=c)
+    thetas = [idx * (4 * math.pi) / max(n - 1, 1) for idx in range(n)]
+    points = []
+    for theta in thetas:
+        vector = spiral.map(theta).tolist()
+        points.append({
+            "theta": theta,
+            "coordinates": vector,
+        })
+    return {"points": points, "params": {"a": a, "b": b, "c": c}}
+
+
+@router.get("/tic")
+def get_tic_state() -> Dict[str, object]:
+    """Return the condensed TIC state and a deterministic history."""
+
+    tic_state = tic_service.to_dict().get("tic")
+    return {
+        "state": tic_state,
+        "history": _tic_history(),
+    }
+
+
+@router.get("/tic/active")
+def get_tic_active_vectors() -> Dict[str, object]:
+    """Return the raw vectors currently stored inside the TIC condensate."""
+
+    if tic_service.state is None:
+        return {"vectors": []}
+    return {"vectors": [tic_service._to_flat_list(tic_service.state)]}
+
+
+@router.get("/ml/train_status")
+def get_ml_train_status() -> Dict[str, object]:
+    """Return a dummy training curve for the ML view."""
+
+    epochs = list(range(1, 11))
+    start = datetime.utcnow() - timedelta(minutes=len(epochs))
+    timeline = [(start + timedelta(minutes=idx)).isoformat() for idx in range(len(epochs))]
+    accuracy = [round(0.5 + 0.05 * math.log(idx + 1), 4) for idx in range(len(epochs))]
+    loss = [round(1.2 / (idx + 1), 4) for idx in range(len(epochs))]
+    return {"epochs": epochs, "timeline": timeline, "accuracy": accuracy, "loss": loss}
+
+
+@router.get("/zkml/proof")
+def get_latest_proof() -> Dict[str, object]:
+    """Return the last ZKML proof produced through the API."""
+
+    return get_last_proof()

--- a/src/dashboard/backend/services.py
+++ b/src/dashboard/backend/services.py
@@ -1,0 +1,23 @@
+"""Shared service instances exposed to the dashboard and public API."""
+from __future__ import annotations
+
+from ledger import Ledger
+from hdag.hdag import HDAG
+from tic import TIC
+from zkml import ZKML
+
+# Instantiate long-lived services so both the dashboard endpoints and the
+# existing API surface operate on the same state.  This mirrors the globals that
+# previously lived inside ``api.server`` but allows other modules to import them
+# without triggering circular dependencies.
+ledger_service = Ledger()
+hdag_service = HDAG()
+tic_service = TIC()
+zkml_service = ZKML()
+
+__all__ = [
+    "ledger_service",
+    "hdag_service",
+    "tic_service",
+    "zkml_service",
+]

--- a/src/dashboard/backend/state.py
+++ b/src/dashboard/backend/state.py
@@ -1,0 +1,59 @@
+"""Mutable dashboard state shared across API endpoints."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+_DEFAULT_PROOF: Dict[str, Any] = {
+    "input": [],
+    "prediction": None,
+    "proof": "",
+    "statement": "",
+    "verified": False,
+}
+
+_last_proof: Dict[str, Any] = dict(_DEFAULT_PROOF)
+
+
+def set_last_proof(proof: Dict[str, Any]) -> None:
+    """Store the latest ZKML proof result returned by the pipeline."""
+
+    global _last_proof
+    # Normalise to a JSON-friendly payload and keep only known keys so we don't
+    # accidentally leak large tensors to the frontend consumers.
+    cleaned: Dict[str, Any] = dict(_DEFAULT_PROOF)
+    cleaned.update({k: proof.get(k) for k in cleaned.keys() if k in proof})
+    # Ensure inputs are converted to plain Python lists for serialisation.
+    vector = proof.get("input") or proof.get("vector")
+    if vector is not None:
+        if hasattr(vector, "tolist"):
+            cleaned["input"] = list(vector.tolist())
+        elif isinstance(vector, (list, tuple)):
+            cleaned["input"] = [float(v) for v in vector]
+    prediction = proof.get("prediction")
+    if hasattr(prediction, "item"):
+        try:
+            prediction = float(prediction.item())
+        except Exception:  # pragma: no cover - defensive conversion
+            prediction = float(prediction)
+    if isinstance(prediction, (int, float)):
+        cleaned["prediction"] = float(prediction)
+    cleaned["proof"] = str(proof.get("proof", cleaned["proof"]))
+    cleaned["statement"] = str(proof.get("statement", cleaned["statement"]))
+    cleaned["verified"] = bool(proof.get("verified", cleaned["verified"]))
+    _last_proof = cleaned
+
+
+def get_last_proof() -> Dict[str, Any]:
+    """Return the latest proof payload served to the dashboard."""
+
+    return dict(_last_proof)
+
+
+def reset_last_proof() -> None:
+    """Reset the stored proof to its default empty state."""
+
+    global _last_proof
+    _last_proof = dict(_DEFAULT_PROOF)
+
+
+__all__ = ["get_last_proof", "reset_last_proof", "set_last_proof"]

--- a/src/dashboard/frontend/index.html
+++ b/src/dashboard/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rings of Saturn Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/src/dashboard/frontend/package.json
+++ b/src/dashboard/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "rings-of-saturn-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "d3": "^7.8.5",
+    "plotly.js-dist-min": "^2.27.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/react": "^14.0.0",
+    "@types/react": "^18.2.33",
+    "@types/react-dom": "^18.2.14",
+    "@vitejs/plugin-react": "^4.0.4",
+    "jsdom": "^22.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.2",
+    "vitest": "^0.34.6",
+    "whatwg-fetch": "^3.6.20"
+  }
+}

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import LedgerView from './components/LedgerView';
+import HdagView from './components/HdagView';
+import SpiralView from './components/SpiralView';
+import TicView from './components/TicView';
+import MlView from './components/MlView';
+import ZkmlView from './components/ZkmlView';
+
+const App: React.FC = () => {
+  return (
+    <main>
+      <header>
+        <h1>Rings of Saturn Dashboard</h1>
+        <p>Interactive exploration of ledger, HDAG, TIC and ZKML subsystems.</p>
+      </header>
+      <div className="grid">
+        <LedgerView />
+        <HdagView />
+      </div>
+      <SpiralView />
+      <div className="grid">
+        <TicView />
+        <MlView />
+      </div>
+      <ZkmlView />
+    </main>
+  );
+};
+
+export default App;

--- a/src/dashboard/frontend/src/components/HdagView.tsx
+++ b/src/dashboard/frontend/src/components/HdagView.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useRef, useState } from 'react';
+import * as d3 from 'd3';
+
+type HdagNode = {
+  id: string;
+  vector: number[];
+  x?: number;
+  y?: number;
+  vx?: number;
+  vy?: number;
+  fx?: number | null;
+  fy?: number | null;
+};
+
+type HdagEdge = {
+  source: string;
+  target: string;
+  weight: number;
+};
+
+type HdagResponse = {
+  nodes: HdagNode[];
+  edges: HdagEdge[];
+};
+
+const useHdagData = () => {
+  const [data, setData] = useState<HdagResponse>({ nodes: [], edges: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const response = await fetch('/dashboard/hdag');
+        if (!response.ok) {
+          throw new Error(`Failed to load HDAG: ${response.statusText}`);
+        }
+        const payload = (await response.json()) as HdagResponse;
+        if (!cancelled) {
+          setData(payload);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, loading, error };
+};
+
+const HdagView: React.FC = () => {
+  const { data, loading, error } = useHdagData();
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  useEffect(() => {
+    const svgElement = svgRef.current;
+    if (!svgElement) {
+      return;
+    }
+    const width = svgElement.clientWidth || 600;
+    const height = 360;
+
+    const svg = d3.select(svgElement);
+    svg.selectAll('*').remove();
+    svg.attr('viewBox', `0 0 ${width} ${height}`);
+
+    if (data.nodes.length === 0) {
+      svg
+        .append('text')
+        .attr('x', width / 2)
+        .attr('y', height / 2)
+        .attr('text-anchor', 'middle')
+        .attr('fill', '#9ca3af')
+        .text('No nodes available. Use the API to seed the HDAG.');
+      return;
+    }
+
+    const simulation = d3
+      .forceSimulation(data.nodes)
+      .force(
+        'link',
+        d3
+          .forceLink(data.edges)
+          .id((d: d3.SimulationNodeDatum & HdagNode) => d.id)
+          .distance((edge) => {
+            const weight = (edge as unknown as HdagEdge).weight ?? 0.5;
+            return 180 - 60 * weight;
+          })
+      )
+      .force('charge', d3.forceManyBody().strength(-250))
+      .force('center', d3.forceCenter(width / 2, height / 2));
+
+    const link = svg
+      .append('g')
+      .attr('stroke', 'rgba(255,255,255,0.4)')
+      .selectAll('line')
+      .data(data.edges)
+      .enter()
+      .append('line')
+      .attr('stroke-width', (d) => Math.max(1, d.weight * 2));
+
+    const node = svg
+      .append('g')
+      .selectAll('circle')
+      .data(data.nodes)
+      .enter()
+      .append('circle')
+      .attr('r', 14)
+      .attr('fill', '#6a5acd')
+      .call(
+        d3
+          .drag<SVGCircleElement, HdagNode>()
+          .on('start', (event, d) => {
+            if (!event.active) simulation.alphaTarget(0.3).restart();
+            d.fx = d.x;
+            d.fy = d.y;
+          })
+          .on('drag', (event, d) => {
+            d.fx = event.x;
+            d.fy = event.y;
+          })
+          .on('end', (event, d) => {
+            if (!event.active) simulation.alphaTarget(0);
+            d.fx = null;
+            d.fy = null;
+          })
+      );
+
+    const labels = svg
+      .append('g')
+      .selectAll('text')
+      .data(data.nodes)
+      .enter()
+      .append('text')
+      .text((d) => d.id)
+      .attr('fill', '#f4f6fb')
+      .attr('font-size', 12)
+      .attr('text-anchor', 'middle')
+      .attr('dy', 28);
+
+    simulation.on('tick', () => {
+      link
+        .attr('x1', (d: any) => (d.source.x as number) ?? 0)
+        .attr('y1', (d: any) => (d.source.y as number) ?? 0)
+        .attr('x2', (d: any) => (d.target.x as number) ?? 0)
+        .attr('y2', (d: any) => (d.target.y as number) ?? 0);
+
+      node.attr('cx', (d: any) => d.x as number).attr('cy', (d: any) => d.y as number);
+      labels
+        .attr('x', (d: any) => d.x as number)
+        .attr('y', (d: any) => (d.y as number) ?? 0);
+    });
+
+    return () => {
+      simulation.stop();
+    };
+  }, [data]);
+
+  return (
+    <section aria-labelledby="hdag-heading">
+      <h2 id="hdag-heading">HDAG</h2>
+      {loading && <p>Loading HDAG…</p>}
+      {error && <p className="error">{error}</p>}
+      <svg ref={svgRef} role="img" aria-label="HDAG force-directed graph" />
+    </section>
+  );
+};
+
+export default HdagView;

--- a/src/dashboard/frontend/src/components/LedgerView.tsx
+++ b/src/dashboard/frontend/src/components/LedgerView.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from 'react';
+
+type LedgerBlock = {
+  index: number;
+  hash: string;
+  prev_hash?: string;
+  projection?: number[];
+  transactions?: Array<Record<string, unknown>>;
+};
+
+type LedgerResponse = {
+  chain: LedgerBlock[];
+  pending: Array<Record<string, unknown>>;
+};
+
+const LedgerView: React.FC = () => {
+  const [data, setData] = useState<LedgerResponse>({ chain: [], pending: [] });
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const response = await fetch('/dashboard/ledger');
+        if (!response.ok) {
+          throw new Error(`Failed to load ledger: ${response.statusText}`);
+        }
+        const payload = (await response.json()) as LedgerResponse;
+        if (!cancelled) {
+          setData(payload);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <section aria-labelledby="ledger-heading">
+      <h2 id="ledger-heading">Ledger</h2>
+      {loading && <p>Loading ledger…</p>}
+      {error && <p className="error">{error}</p>}
+      {!loading && !error && (
+        <>
+          <p>
+            Pending transactions: <strong>{data.pending.length}</strong>
+          </p>
+          <div style={{ overflowX: 'auto' }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Hash</th>
+                  <th>Previous</th>
+                  <th>Projection (x₁, x₂, x₃)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.chain.length === 0 && (
+                  <tr>
+                    <td colSpan={4} style={{ textAlign: 'center', opacity: 0.7 }}>
+                      No blocks created yet. Interact with the API to populate the chain.
+                    </td>
+                  </tr>
+                )}
+                {data.chain.map((block) => (
+                  <tr key={block.hash}>
+                    <td>{block.index}</td>
+                    <td>{block.hash.slice(0, 12)}…</td>
+                    <td>{block.prev_hash ? `${block.prev_hash.slice(0, 12)}…` : 'genesis'}</td>
+                    <td>
+                      {block.projection?.length ? (
+                        block.projection
+                          .slice(0, 3)
+                          .map((value) => value.toFixed(3))
+                          .join(', ')
+                      ) : (
+                        <span style={{ opacity: 0.7 }}>n/a</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default LedgerView;

--- a/src/dashboard/frontend/src/components/MlView.tsx
+++ b/src/dashboard/frontend/src/components/MlView.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Plotly from 'plotly.js-dist-min';
+
+type MlResponse = {
+  epochs: number[];
+  timeline: string[];
+  accuracy: number[];
+  loss: number[];
+};
+
+const MlView: React.FC = () => {
+  const [data, setData] = useState<MlResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const plotRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const response = await fetch('/dashboard/ml/train_status');
+        if (!response.ok) {
+          throw new Error(`Failed to load ML status: ${response.statusText}`);
+        }
+        const payload = (await response.json()) as MlResponse;
+        if (!cancelled) {
+          setData(payload);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!plotRef.current || !data) {
+      return;
+    }
+
+    const accuracyTrace = {
+      x: data.epochs,
+      y: data.accuracy,
+      mode: 'lines+markers',
+      name: 'Accuracy',
+      line: { color: '#7dd3fc' }
+    };
+
+    const lossTrace = {
+      x: data.epochs,
+      y: data.loss,
+      mode: 'lines+markers',
+      name: 'Loss',
+      yaxis: 'y2',
+      line: { color: '#f87171' }
+    };
+
+    const layout = {
+      title: 'Demo training metrics',
+      paper_bgcolor: 'transparent',
+      plot_bgcolor: 'transparent',
+      xaxis: { title: 'Epoch', color: '#f4f6fb' },
+      yaxis: { title: 'Accuracy', color: '#7dd3fc', rangemode: 'tozero' as const },
+      yaxis2: {
+        title: 'Loss',
+        overlaying: 'y' as const,
+        side: 'right' as const,
+        color: '#f87171',
+        rangemode: 'tozero' as const
+      },
+      legend: { orientation: 'h' as const },
+      margin: { l: 50, r: 50, t: 40, b: 40 }
+    };
+
+    Plotly.newPlot(plotRef.current, [accuracyTrace, lossTrace], layout, { responsive: true });
+
+    return () => {
+      Plotly.purge(plotRef.current as HTMLDivElement);
+    };
+  }, [data]);
+
+  return (
+    <section aria-labelledby="ml-heading">
+      <h2 id="ml-heading">ML Training</h2>
+      {loading && <p>Loading training curve…</p>}
+      {error && <p className="error">{error}</p>}
+      <div ref={plotRef} style={{ width: '100%', height: '320px' }} />
+    </section>
+  );
+};
+
+export default MlView;

--- a/src/dashboard/frontend/src/components/SpiralView.tsx
+++ b/src/dashboard/frontend/src/components/SpiralView.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Plotly from 'plotly.js-dist-min';
+
+type SpiralParams = {
+  a: number;
+  b: number;
+  c: number;
+};
+
+type SpiralPoint = {
+  theta: number;
+  coordinates: number[];
+};
+
+type SpiralResponse = {
+  points: SpiralPoint[];
+  params: SpiralParams;
+};
+
+const DEFAULT_PARAMS: SpiralParams = { a: 1, b: 0.5, c: 0.1 };
+
+const SpiralView: React.FC = () => {
+  const [params, setParams] = useState<SpiralParams>(DEFAULT_PARAMS);
+  const [points, setPoints] = useState<SpiralPoint[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const plotRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const query = new URLSearchParams({
+          n: '200',
+          a: params.a.toString(),
+          b: params.b.toString(),
+          c: params.c.toString()
+        });
+        const response = await fetch(`/dashboard/spiral?${query.toString()}`);
+        if (!response.ok) {
+          throw new Error(`Failed to load spiral: ${response.statusText}`);
+        }
+        const payload = (await response.json()) as SpiralResponse;
+        if (!cancelled) {
+          setPoints(payload.points);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [params]);
+
+  useEffect(() => {
+    if (!plotRef.current || points.length === 0) {
+      return;
+    }
+    const xs = points.map((point) => point.coordinates[0]);
+    const ys = points.map((point) => point.coordinates[1]);
+    const zs = points.map((point) => point.coordinates[2]);
+
+    const trace = {
+      x: xs,
+      y: ys,
+      z: zs,
+      mode: 'lines+markers',
+      type: 'scatter3d' as const,
+      marker: { size: 3, color: points.map((p) => p.theta), colorscale: 'Viridis' },
+      line: { width: 2, color: '#6a5acd' }
+    };
+
+    const layout = {
+      autosize: true,
+      title: 'Spiral Projection (3D)',
+      paper_bgcolor: 'transparent',
+      plot_bgcolor: 'transparent',
+      scene: {
+        xaxis: { title: 'x₁', color: '#f4f6fb' },
+        yaxis: { title: 'x₂', color: '#f4f6fb' },
+        zaxis: { title: 'x₃', color: '#f4f6fb' }
+      },
+      margin: { l: 0, r: 0, b: 0, t: 40 }
+    };
+
+    Plotly.newPlot(plotRef.current, [trace], layout, { responsive: true });
+
+    return () => {
+      Plotly.purge(plotRef.current as HTMLDivElement);
+    };
+  }, [points]);
+
+  const handleParamChange = (key: keyof SpiralParams) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseFloat(event.target.value);
+    setParams((prev) => ({ ...prev, [key]: value }));
+  };
+
+  return (
+    <section aria-labelledby="spiral-heading">
+      <h2 id="spiral-heading">Spiral</h2>
+      <div className="controls">
+        <label>
+          a: {params.a.toFixed(2)}
+          <input type="range" min="0.2" max="2" step="0.05" value={params.a} onChange={handleParamChange('a')} />
+        </label>
+        <label>
+          b: {params.b.toFixed(2)}
+          <input type="range" min="0.1" max="1.5" step="0.05" value={params.b} onChange={handleParamChange('b')} />
+        </label>
+        <label>
+          c: {params.c.toFixed(2)}
+          <input type="range" min="0.05" max="0.5" step="0.01" value={params.c} onChange={handleParamChange('c')} />
+        </label>
+      </div>
+      {loading && <p>Generating spiral…</p>}
+      {error && <p className="error">{error}</p>}
+      <div ref={plotRef} style={{ width: '100%', height: '420px' }} />
+    </section>
+  );
+};
+
+export default SpiralView;

--- a/src/dashboard/frontend/src/components/TicView.tsx
+++ b/src/dashboard/frontend/src/components/TicView.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Plotly from 'plotly.js-dist-min';
+
+type TicResponse = {
+  state: number[] | null;
+  history: number[][];
+};
+
+const TicView: React.FC = () => {
+  const [state, setState] = useState<number[] | null>(null);
+  const [history, setHistory] = useState<number[][]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const plotRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const response = await fetch('/dashboard/tic');
+        if (!response.ok) {
+          throw new Error(`Failed to load TIC state: ${response.statusText}`);
+        }
+        const payload = (await response.json()) as TicResponse;
+        if (!cancelled) {
+          setState(payload.state ?? null);
+          setHistory(payload.history ?? []);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!plotRef.current || history.length === 0) {
+      return;
+    }
+
+    const xs = history.map((vec) => vec[0] ?? 0);
+    const ys = history.map((vec) => vec[1] ?? 0);
+    const zs = history.map((vec) => vec[2] ?? 0);
+
+    const trace = {
+      x: xs,
+      y: ys,
+      mode: 'markers',
+      type: 'scatter',
+      marker: {
+        size: 10,
+        color: zs,
+        colorscale: 'Portland',
+        showscale: true
+      },
+      text: history.map((vec, idx) => `v${idx}: ${vec.map((v) => v.toFixed(2)).join(', ')}`)
+    };
+
+    const highlight =
+      state && state.length >= 2
+        ? [{
+            x: [state[0]],
+            y: [state[1]],
+            mode: 'markers',
+            type: 'scatter',
+            marker: { size: 14, color: '#ffdd57', symbol: 'star' },
+            name: 'Condensate'
+          }]
+        : [];
+
+    const layout = {
+      title: 'TIC condensed vectors',
+      paper_bgcolor: 'transparent',
+      plot_bgcolor: 'transparent',
+      xaxis: { title: 'Component 1', color: '#f4f6fb' },
+      yaxis: { title: 'Component 2', color: '#f4f6fb' },
+      margin: { l: 40, r: 10, b: 40, t: 40 }
+    };
+
+    Plotly.newPlot(plotRef.current, [trace, ...highlight], layout, { responsive: true });
+
+    return () => {
+      Plotly.purge(plotRef.current as HTMLDivElement);
+    };
+  }, [history, state]);
+
+  return (
+    <section aria-labelledby="tic-heading">
+      <h2 id="tic-heading">TIC Condensate</h2>
+      {loading && <p>Loading TIC vectors…</p>}
+      {error && <p className="error">{error}</p>}
+      {state && (
+        <p>
+          Current condensate:{' '}
+          <code>{state.map((value) => value.toFixed(3)).join(', ')}</code>
+        </p>
+      )}
+      <div ref={plotRef} style={{ width: '100%', height: '360px' }} />
+    </section>
+  );
+};
+
+export default TicView;

--- a/src/dashboard/frontend/src/components/ZkmlView.tsx
+++ b/src/dashboard/frontend/src/components/ZkmlView.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+
+type ProofPayload = {
+  input: number[];
+  prediction: number | null;
+  proof: string;
+  statement: string;
+  verified: boolean;
+};
+
+const defaultProof: ProofPayload = {
+  input: [],
+  prediction: null,
+  proof: '',
+  statement: '',
+  verified: false
+};
+
+const parseVector = (value: string): number[] => {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+    .map((item) => Number.parseFloat(item))
+    .filter((num) => !Number.isNaN(num));
+};
+
+const ZkmlView: React.FC = () => {
+  const [vectorInput, setVectorInput] = useState<string>('1, 0.5, -0.5');
+  const [proof, setProof] = useState<ProofPayload>(defaultProof);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadProof = async () => {
+      try {
+        const response = await fetch('/dashboard/zkml/proof');
+        if (!response.ok) {
+          throw new Error('Unable to retrieve previous proof');
+        }
+        const payload = (await response.json()) as ProofPayload;
+        if (!cancelled) {
+          setProof({ ...defaultProof, ...payload });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unknown error');
+        }
+      }
+    };
+    void loadProof();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    const vector = parseVector(vectorInput);
+    if (vector.length === 0) {
+      setError('Provide at least one numeric value.');
+      return;
+    }
+    setLoading(true);
+    try {
+      const inferResponse = await fetch('/zkml/zk_infer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ vector })
+      });
+      if (!inferResponse.ok) {
+        throw new Error(`Inference failed: ${inferResponse.statusText}`);
+      }
+      const inferPayload = (await inferResponse.json()) as ProofPayload;
+      let verified = false;
+      if (inferPayload.statement && inferPayload.proof) {
+        const verifyResponse = await fetch('/zkml/verify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ statement: inferPayload.statement, proof: inferPayload.proof })
+        });
+        if (verifyResponse.ok) {
+          const verifyPayload = (await verifyResponse.json()) as { valid: boolean };
+          verified = verifyPayload.valid;
+        }
+      }
+      setProof({
+        input: vector,
+        prediction: inferPayload.prediction,
+        proof: inferPayload.proof,
+        statement: inferPayload.statement,
+        verified
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section aria-labelledby="zkml-heading">
+      <h2 id="zkml-heading">ZKML Inference</h2>
+      <form onSubmit={handleSubmit} style={{ display: 'grid', gap: '0.75rem', maxWidth: '480px' }}>
+        <label>
+          Input vector
+          <input
+            type="text"
+            value={vectorInput}
+            onChange={(event) => setVectorInput(event.target.value)}
+            placeholder="e.g. 0.5, 1.2, -0.3"
+          />
+        </label>
+        <button type="submit" disabled={loading}>
+          {loading ? 'Generating proof…' : 'Infer & generate proof'}
+        </button>
+        {error && <p className="error">{error}</p>}
+      </form>
+      <div>
+        <h3>Latest proof</h3>
+        <p>
+          <strong>Input:</strong> {proof.input.length ? proof.input.join(', ') : 'n/a'}
+        </p>
+        <p>
+          <strong>Prediction:</strong>{' '}
+          {proof.prediction !== null ? proof.prediction.toFixed(4) : 'n/a'}
+        </p>
+        <p>
+          <strong>Statement:</strong> {proof.statement ? <code>{proof.statement}</code> : 'n/a'}
+        </p>
+        <p>
+          <strong>Proof:</strong>{' '}
+          {proof.proof ? <code style={{ wordBreak: 'break-all' }}>{proof.proof}</code> : 'n/a'}
+        </p>
+        <p>
+          <strong>Verified:</strong>{' '}
+          <span style={{ color: proof.verified ? '#34d399' : '#f87171' }}>
+            {proof.verified ? 'valid' : 'unverified'}
+          </span>
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export default ZkmlView;

--- a/src/dashboard/frontend/src/components/__tests__/App.test.tsx
+++ b/src/dashboard/frontend/src/components/__tests__/App.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import App from '../../App';
+
+const jsonResponse = (data: unknown) =>
+  Promise.resolve(
+    new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  );
+
+describe('App dashboard shell', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.startsWith('/dashboard/ledger')) {
+        return jsonResponse({ chain: [], pending: [] });
+      }
+      if (url.startsWith('/dashboard/hdag')) {
+        return jsonResponse({ nodes: [], edges: [] });
+      }
+      if (url.startsWith('/dashboard/spiral')) {
+        return jsonResponse({
+          points: [
+            { theta: 0, coordinates: [0, 0, 0, 0, 0] },
+            { theta: 1, coordinates: [1, 1, 0.5, 0.5, 0.1] }
+          ],
+          params: { a: 1, b: 0.5, c: 0.1 }
+        });
+      }
+      if (url.startsWith('/dashboard/tic')) {
+        return jsonResponse({ state: [0.1, 0.2, 0.3], history: [[0, 0, 0], [0.1, 0.2, 0.3]] });
+      }
+      if (url.startsWith('/dashboard/ml/train_status')) {
+        return jsonResponse({
+          epochs: [1, 2],
+          timeline: [],
+          accuracy: [0.5, 0.6],
+          loss: [1.0, 0.8]
+        });
+      }
+      if (url.startsWith('/dashboard/zkml/proof')) {
+        return jsonResponse({
+          input: [1, 2, 3],
+          prediction: 0.75,
+          proof: 'proof',
+          statement: 'statement',
+          verified: true
+        });
+      }
+      if (url.startsWith('/zkml/verify')) {
+        return jsonResponse({ valid: true });
+      }
+      return jsonResponse({});
+    }) as typeof fetch;
+  });
+
+  it('renders all dashboard sections', async () => {
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/Rings of Saturn Dashboard/i)).toBeInTheDocument());
+    expect(await screen.findByText(/Ledger/i)).toBeInTheDocument();
+    expect(await screen.findByText(/HDAG/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Spiral/i)).toBeInTheDocument();
+    expect(await screen.findByText(/TIC Condensate/i)).toBeInTheDocument();
+    expect(await screen.findByText(/ML Training/i)).toBeInTheDocument();
+    expect(await screen.findByText(/ZKML Inference/i)).toBeInTheDocument();
+  });
+});

--- a/src/dashboard/frontend/src/index.css
+++ b/src/dashboard/frontend/src/index.css
@@ -1,0 +1,94 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0b0d17;
+  color: #f4f6fb;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+h2 {
+  margin-top: 0;
+}
+
+main {
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+section {
+  background: rgba(21, 25, 44, 0.85);
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+th,
+ td {
+  padding: 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+input,
+button {
+  font-family: inherit;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: none;
+}
+
+button {
+  background: #6a5acd;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:disabled {
+  background: rgba(255, 255, 255, 0.2);
+  cursor: not-allowed;
+}
+
+label {
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: #ff7a7a;
+}
+
+svg {
+  width: 100%;
+  height: 360px;
+}

--- a/src/dashboard/frontend/src/index.tsx
+++ b/src/dashboard/frontend/src/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const container = document.getElementById('root');
+
+if (!container) {
+  throw new Error('Root container missing in index.html');
+}
+
+ReactDOM.createRoot(container).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/dashboard/frontend/src/setupTests.ts
+++ b/src/dashboard/frontend/src/setupTests.ts
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom';
+import 'whatwg-fetch';
+import { vi } from 'vitest';
+
+// Mock Plotly during unit tests to avoid requiring a full WebGL context.
+vi.mock('plotly.js-dist-min', () => ({
+  __esModule: true,
+  default: {
+    newPlot: vi.fn(),
+    purge: vi.fn()
+  }
+}));

--- a/src/dashboard/frontend/tsconfig.json
+++ b/src/dashboard/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/src/dashboard/frontend/tsconfig.node.json
+++ b/src/dashboard/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/src/dashboard/frontend/vite.config.ts
+++ b/src/dashboard/frontend/vite.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/dashboard': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      },
+      '/ledger': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      },
+      '/hdag': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      },
+      '/tic': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      },
+      '/ml': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      },
+      '/zkml': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      }
+    }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts'
+  }
+});

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -1,0 +1,64 @@
+"""Integration tests for the dashboard FastAPI router."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from api.server import app, reset_state
+
+client = TestClient(app)
+
+
+def setup_function() -> None:
+    reset_state()
+
+
+def test_get_ledger() -> None:
+    response = client.get("/dashboard/ledger")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "chain" in payload and isinstance(payload["chain"], list)
+    assert "pending" in payload and isinstance(payload["pending"], list)
+
+
+def test_get_hdag() -> None:
+    response = client.get("/dashboard/hdag")
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data.keys()) == {"nodes", "edges"}
+    assert isinstance(data["nodes"], list)
+    assert isinstance(data["edges"], list)
+
+
+def test_get_spiral() -> None:
+    response = client.get("/dashboard/spiral?n=5&a=1&b=0.5&c=0.1")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "points" in payload
+    assert len(payload["points"]) == 5
+    first_point = payload["points"][0]
+    assert "coordinates" in first_point and len(first_point["coordinates"]) == 5
+
+
+def test_get_tic_state() -> None:
+    response = client.get("/dashboard/tic")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "history" in payload and isinstance(payload["history"], list)
+
+
+def test_ml_status() -> None:
+    response = client.get("/dashboard/ml/train_status")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "accuracy" in payload and len(payload["accuracy"]) == len(payload["epochs"])
+
+
+def test_get_latest_proof_updates_on_infer() -> None:
+    # Ensure inference populates the shared proof state
+    infer_response = client.post("/zkml/zk_infer", json={"vector": [1.0, 2.0, 3.0]})
+    assert infer_response.status_code == 200
+    proof_response = client.get("/dashboard/zkml/proof")
+    assert proof_response.status_code == 200
+    proof_payload = proof_response.json()
+    assert proof_payload["input"] == [1.0, 2.0, 3.0]
+    assert proof_payload["proof"]


### PR DESCRIPTION
## Summary
- add shared dashboard backend services and API router with ledger, HDAG, TIC, spiral, ML and ZKML endpoints
- integrate the dashboard router and static asset mounting into the FastAPI server while extending local FastAPI stubs
- scaffold a Vite + React dashboard UI with Plotly/D3 visualisations and component tests, plus backend integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9e6a584cc83319e3ff4e9f8cd2bf6